### PR TITLE
Add workflow to format, build and test all crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,14 +9,24 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  find-crates:
+    name: Find all crates
+    runs-on: ubuntu-latest
+    outputs:
+      crates: ${{ steps.find.outputs.crates }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Find crates
+        id: find
+        run: echo "::set-output name=crates::$(find -name Cargo.toml -printf '%h\n' | sed 's:./::' | jq -R | jq -sc)"
+
   format:
     name: Format
+    needs: find-crates
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory:
-          - hovercontrol
-          - hoverkite-firmware
+        directory: ${{ fromJSON(needs.find-crates.outputs.crates) }}
     defaults:
       run:
         working-directory: ${{ matrix.directory }}
@@ -27,12 +37,11 @@ jobs:
 
   build:
     name: Build and test
+    needs: find-crates
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory:
-          - hovercontrol
-          - hoverkite-firmware
+        directory: ${{ fromJSON(needs.find-crates.outputs.crates) }}
     defaults:
       run:
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ jobs:
         working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt-get install libudev-dev
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,6 @@ jobs:
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
+          name: clippy ${{ matrix.directory }}
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,11 @@ jobs:
         working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7m-none-eabi
       - name: Build
         run: cargo build --all-features
       - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   format:
     name: Format
@@ -21,3 +24,26 @@ jobs:
       - uses: actions/checkout@v2
       - name: Format Rust code
         run: cargo fmt --all -- --check
+
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory:
+          - hovercontrol
+          - hoverkite-firmware
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --all-features
+      - name: Run tests
+        run: cargo test --all-features
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,4 @@ jobs:
       - name: Run tests
         run: cargo test
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          name: clippy ${{ matrix.directory }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --manifest-path ${{ matrix.directory }}/Cargo.toml
+        run: cargo clippy # -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,4 +54,4 @@ jobs:
         with:
           name: clippy ${{ matrix.directory }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --manifest-path ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,9 +46,9 @@ jobs:
           toolchain: stable
           target: thumbv7m-none-eabi
       - name: Build
-        run: cargo build --all-features
+        run: cargo build
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory:
+          - hovercontrol
+          - hoverkite-firmware
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Format Rust code
+        run: cargo fmt --all -- --check

--- a/hoverkite-firmware/src/main.rs
+++ b/hoverkite-firmware/src/main.rs
@@ -80,7 +80,9 @@ fn main() -> ! {
     let mut last_position = 0;
     let mut command_buffer = [0; 12];
     let mut command_len = 0;
+    #[cfg(feature = "primary")]
     let mut proxy_response_buffer = [0; 100];
+    #[cfg(feature = "primary")]
     let mut proxy_response_length = 0;
     let mut speed;
     let mut target_position: Option<i64> = None;

--- a/hoverkite-firmware/src/protocol.rs
+++ b/hoverkite-firmware/src/protocol.rs
@@ -77,10 +77,13 @@ pub fn process_response(response: &[u8], hoverboard: &mut Hoverboard) -> bool {
     true
 }
 
+#[cfg(feature = "primary")]
 fn forward_command(hoverboard: &mut Hoverboard, command: &[u8]) {
-    #[cfg(feature = "primary")]
     hoverboard.serial_writer.bwrite_all(command).unwrap();
-    #[cfg(feature = "secondary")]
+}
+
+#[cfg(feature = "secondary")]
+fn forward_command(hoverboard: &mut Hoverboard, _command: &[u8]) {
     log!(hoverboard.response_tx(), "Secondary can't forward.");
 }
 


### PR DESCRIPTION
This searches for all directories containing a `Cargo.toml` and runs the jobs there.

Unfortunately https://github.com/actions-rs/clippy-check doesn't support running under a subdirectory (https://github.com/actions-rs/clippy-check/issues/28) so we can't use that for Clippy checks. I'm just running clippy manually instead, but not doing anything useful with the output. `hoverkite-firmware` currently has a bunch of clippy warnings due to how the feature flags work.

I'm also currently only testing with the default feature flags, which means it doesn't cover the `primary` feature for `hoverkite-firmware`. I'm not sure how best to handle that.