### PR TITLE
Protocol cleanups

### DIFF
--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -288,5 +288,26 @@ mod tests {
 
             assert_eq!(round_tripped_command, Err(WouldBlock))
         }
+
+        #[test_case(SetSideLed(true))]
+        #[test_case(SetOrangeLed(false))]
+        #[test_case(SetRedLed(true))]
+        #[test_case(SetGreenLed(false))]
+        #[test_case(SetMaxSpeed(-30..=42))]
+        #[test_case(SetSpringConstant(42))]
+        #[test_case(SetTarget(-42))]
+        #[test_case(Recenter)]
+        #[test_case(ReportBattery)]
+        #[test_case(ReportCharger)]
+        #[test_case(RemoveTarget)]
+        #[test_case(PowerOff)]
+        fn parse_error_if_extra_byte(command: Command) {
+            let mut buf = vec![];
+            command.write_to_std(&mut buf).unwrap();
+            buf.push(42);
+            let round_tripped_command = Command::parse(&buf);
+
+            assert_eq!(round_tripped_command, Err(Other(ParseError)))
+        }
     }
 }

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -343,11 +343,12 @@ mod tests {
         #[test_case(DecrementTarget)]
         #[test_case(PowerOff)]
         fn round_trip_equality(command: Command) {
+            let message = Message::from(command);
             let mut buf = vec![];
-            command.write_to_std(&mut buf).unwrap();
-            let round_tripped_command = Command::parse(&buf).unwrap();
+            message.write_to_std(&mut buf).unwrap();
+            let round_tripped_message = Message::parse(&buf).unwrap();
 
-            assert_eq!(round_tripped_command, command)
+            assert_eq!(round_tripped_message, message)
         }
 
         #[test_case(SetSideLed(true))]

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -87,30 +87,30 @@ impl Command {
         W: embedded_hal::blocking::serial::Write<u8>,
     {
         match self {
-            Command::SetSideLed(on) => writer.bwrite_all(&[b'l', bool_to_ascii(*on)])?,
-            Command::SetOrangeLed(on) => writer.bwrite_all(&[b'o', bool_to_ascii(*on)])?,
-            Command::SetRedLed(on) => writer.bwrite_all(&[b'r', bool_to_ascii(*on)])?,
-            Command::SetGreenLed(on) => writer.bwrite_all(&[b'g', bool_to_ascii(*on)])?,
-            Command::SetMaxSpeed(max_speed) => {
+            Self::SetSideLed(on) => writer.bwrite_all(&[b'l', bool_to_ascii(*on)])?,
+            Self::SetOrangeLed(on) => writer.bwrite_all(&[b'o', bool_to_ascii(*on)])?,
+            Self::SetRedLed(on) => writer.bwrite_all(&[b'r', bool_to_ascii(*on)])?,
+            Self::SetGreenLed(on) => writer.bwrite_all(&[b'g', bool_to_ascii(*on)])?,
+            Self::SetMaxSpeed(max_speed) => {
                 writer.bwrite_all(&[b'S'])?;
                 writer.bwrite_all(&max_speed.start().to_le_bytes())?;
                 writer.bwrite_all(&max_speed.end().to_le_bytes())?;
             }
-            Command::SetSpringConstant(spring_constant) => {
+            Self::SetSpringConstant(spring_constant) => {
                 writer.bwrite_all(&[b'K'])?;
                 writer.bwrite_all(&spring_constant.to_le_bytes())?;
             }
-            Command::SetTarget(target) => {
+            Self::SetTarget(target) => {
                 writer.bwrite_all(&[b'T'])?;
                 writer.bwrite_all(&target.to_le_bytes())?;
             }
-            Command::Recenter => writer.bwrite_all(&[b'e'])?,
-            Command::ReportBattery => writer.bwrite_all(&[b'b'])?,
-            Command::ReportCharger => writer.bwrite_all(&[b'c'])?,
-            Command::RemoveTarget => writer.bwrite_all(&[b'n'])?,
-            Command::IncrementTarget => writer.bwrite_all(&[b'+'])?,
-            Command::DecrementTarget => writer.bwrite_all(&[b'-'])?,
-            Command::PowerOff => writer.bwrite_all(&[b'p'])?,
+            Self::Recenter => writer.bwrite_all(&[b'e'])?,
+            Self::ReportBattery => writer.bwrite_all(&[b'b'])?,
+            Self::ReportCharger => writer.bwrite_all(&[b'c'])?,
+            Self::RemoveTarget => writer.bwrite_all(&[b'n'])?,
+            Self::IncrementTarget => writer.bwrite_all(&[b'+'])?,
+            Self::DecrementTarget => writer.bwrite_all(&[b'-'])?,
+            Self::PowerOff => writer.bwrite_all(&[b'p'])?,
         };
         Ok(())
     }

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -325,6 +325,8 @@ mod tests {
         #[test_case(ReportBattery)]
         #[test_case(ReportCharger)]
         #[test_case(RemoveTarget)]
+        #[test_case(IncrementTarget)]
+        #[test_case(DecrementTarget)]
         #[test_case(PowerOff)]
         fn round_trip_equality(command: Command) {
             let mut buf = vec![];
@@ -345,6 +347,8 @@ mod tests {
         #[test_case(ReportBattery)]
         #[test_case(ReportCharger)]
         #[test_case(RemoveTarget)]
+        #[test_case(IncrementTarget)]
+        #[test_case(DecrementTarget)]
         #[test_case(PowerOff)]
         fn would_block_if_missing_byte(command: Command) {
             let mut buf = vec![];
@@ -366,6 +370,8 @@ mod tests {
         #[test_case(ReportBattery)]
         #[test_case(ReportCharger)]
         #[test_case(RemoveTarget)]
+        #[test_case(IncrementTarget)]
+        #[test_case(DecrementTarget)]
         #[test_case(PowerOff)]
         fn parse_error_if_extra_byte(command: Command) {
             let mut buf = vec![];

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -318,6 +318,11 @@ mod tests {
 
             assert_eq!(round_tripped_message, Err(Other(ParseError)))
         }
+
+        #[test]
+        fn parse_error_if_bogus_payload() {
+            assert_eq!(Message::parse(&[b'F', 1, b'!']), Err(Other(ParseError)))
+        }
     }
 
     // TODO: see if it's possible to verify this round-trip property

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -121,7 +121,6 @@ impl Command {
             [b'o', on] => Self::SetOrangeLed(ascii_to_bool(on)?),
             [b'r', on] => Self::SetRedLed(ascii_to_bool(on)?),
             [b'g', on] => Self::SetGreenLed(ascii_to_bool(on)?),
-            [] | [b'l'] | [b'o'] | [b'r'] | [b'g'] => return Err(WouldBlock),
             [b'b'] => Self::ReportBattery,
             [b'c'] => Self::ReportCharger,
             [b'S', min_lsb, min_msb, max_lsb, max_msb] => {
@@ -129,22 +128,23 @@ impl Command {
                 let max_power = i16::from_le_bytes([max_lsb, max_msb]);
                 Self::SetMaxSpeed(min_power..=max_power)
             }
-            [b'S', ref rest @ ..] if rest.len() < 4 => return Err(WouldBlock),
             [b'K', lsb, msb] => {
                 let spring = u16::from_le_bytes([lsb, msb]);
                 Self::SetSpringConstant(spring)
             }
-            [b'K', _lsb] => return Err(WouldBlock),
             [b'n'] => Self::RemoveTarget,
             [b'T', b0, b1, b2, b3, b4, b5, b6, b7] => {
                 let target = i64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
                 Self::SetTarget(target)
             }
-            [b'T', ref rest @ ..] if rest.len() < 8 => return Err(WouldBlock),
             [b'e'] => Self::Recenter,
             [b'+'] => Self::IncrementTarget,
             [b'-'] => Self::DecrementTarget,
             [b'p'] => Self::PowerOff,
+            [] | [b'l'] | [b'o'] | [b'r'] | [b'g'] => return Err(WouldBlock),
+            [b'S', ref rest @ ..] if rest.len() < 4 => return Err(WouldBlock),
+            [b'K', _lsb] => return Err(WouldBlock),
+            [b'T', ref rest @ ..] if rest.len() < 8 => return Err(WouldBlock),
             _ => return Err(Other(ParseError)),
         };
         Ok(command)

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -116,42 +116,35 @@ impl Command {
     }
 
     pub fn parse(buf: &[u8]) -> nb::Result<Self, ParseError> {
-        let first = buf.get(0).ok_or(WouldBlock)?;
-        let command = match first {
-            b'l' => Self::SetSideLed(ascii_to_bool(*buf.get(1).ok_or(WouldBlock)?)?),
-            b'o' => Self::SetOrangeLed(ascii_to_bool(*buf.get(1).ok_or(WouldBlock)?)?),
-            b'r' => Self::SetRedLed(ascii_to_bool(*buf.get(1).ok_or(WouldBlock)?)?),
-            b'g' => Self::SetGreenLed(ascii_to_bool(*buf.get(1).ok_or(WouldBlock)?)?),
-            b'b' => Self::ReportBattery,
-            b'c' => Self::ReportCharger,
-            b'S' => {
-                if buf.len() < 5 {
-                    return Err(WouldBlock);
-                }
-                let min_power = i16::from_le_bytes(buf[1..3].try_into().unwrap());
-                let max_power = i16::from_le_bytes(buf[3..5].try_into().unwrap());
-
+        let command = match *buf {
+            [b'l', on] => Self::SetSideLed(ascii_to_bool(on)?),
+            [b'o', on] => Self::SetOrangeLed(ascii_to_bool(on)?),
+            [b'r', on] => Self::SetRedLed(ascii_to_bool(on)?),
+            [b'g', on] => Self::SetGreenLed(ascii_to_bool(on)?),
+            [] | [b'l'] | [b'o'] | [b'r'] | [b'g'] => return Err(WouldBlock),
+            [b'b'] => Self::ReportBattery,
+            [b'c'] => Self::ReportCharger,
+            [b'S', min_lsb, min_msb, max_lsb, max_msb] => {
+                let min_power = i16::from_le_bytes([min_lsb, min_msb]);
+                let max_power = i16::from_le_bytes([max_lsb, max_msb]);
                 Self::SetMaxSpeed(min_power..=max_power)
             }
-            b'K' => {
-                if buf.len() < 3 {
-                    return Err(WouldBlock);
-                }
-                let spring = u16::from_le_bytes(buf[1..3].try_into().unwrap()).into();
+            [b'S', ref rest @ ..] if rest.len() < 4 => return Err(WouldBlock),
+            [b'K', lsb, msb] => {
+                let spring = u16::from_le_bytes([lsb, msb]);
                 Self::SetSpringConstant(spring)
             }
-            b'n' => Self::RemoveTarget,
-            b'T' => {
-                if buf.len() < 9 {
-                    return Err(WouldBlock);
-                }
-                let target = i64::from_le_bytes(buf[1..9].try_into().unwrap());
+            [b'K', _lsb] => return Err(WouldBlock),
+            [b'n'] => Self::RemoveTarget,
+            [b'T', b0, b1, b2, b3, b4, b5, b6, b7] => {
+                let target = i64::from_le_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
                 Self::SetTarget(target)
             }
-            b'e' => Self::Recenter,
-            b'+' => Self::IncrementTarget,
-            b'-' => Self::DecrementTarget,
-            b'p' => Self::PowerOff,
+            [b'T', ref rest @ ..] if rest.len() < 8 => return Err(WouldBlock),
+            [b'e'] => Self::Recenter,
+            [b'+'] => Self::IncrementTarget,
+            [b'-'] => Self::DecrementTarget,
+            [b'p'] => Self::PowerOff,
             _ => return Err(Other(ParseError)),
         };
         Ok(command)
@@ -274,6 +267,26 @@ mod tests {
             let round_tripped_command = Command::parse(&buf).unwrap();
 
             assert_eq!(round_tripped_command, command)
+        }
+
+        #[test_case(SetSideLed(true))]
+        #[test_case(SetOrangeLed(false))]
+        #[test_case(SetRedLed(true))]
+        #[test_case(SetGreenLed(false))]
+        #[test_case(SetMaxSpeed(-30..=42))]
+        #[test_case(SetSpringConstant(42))]
+        #[test_case(SetTarget(-42))]
+        #[test_case(Recenter)]
+        #[test_case(ReportBattery)]
+        #[test_case(ReportCharger)]
+        #[test_case(RemoveTarget)]
+        #[test_case(PowerOff)]
+        fn would_block_if_missing_byte(command: Command) {
+            let mut buf = vec![];
+            command.write_to_std(&mut buf).unwrap();
+            let round_tripped_command = Command::parse(&buf[..buf.len() - 1]);
+
+            assert_eq!(round_tripped_command, Err(WouldBlock))
         }
     }
 }


### PR DESCRIPTION
This is heavily inspired by the tricks used in https://blog.tonari.no/rust-simple-hardware-project 

I also added tests for adding a byte to each Command variant's serialized form and removing a byte from each, to make sure they return ParseError/WouldBlock correctly.