### PR TITLE
MessageReader that implements Read<Message>

### DIFF
--- a/hoverkite-firmware/src/hoverboard.rs
+++ b/hoverkite-firmware/src/hoverboard.rs
@@ -26,6 +26,7 @@ use gd32f1x0_hal::{
     rcu::{Clocks, AHB, APB1, APB2},
     serial::{Config, Rx, Serial, Tx},
 };
+use hoverkite_protocol::MessageReader;
 
 const USART_BAUD_RATE: u32 = 115200;
 const MOTOR_PWM_FREQ_HERTZ: u32 = 16000;
@@ -149,9 +150,9 @@ fn DMA_CHANNEL0() {
 }
 
 pub struct Hoverboard {
-    pub serial_remote_rx: Rx<USART0>,
+    pub serial_remote_rx: MessageReader<Rx<USART0>>,
     pub serial_remote_writer: BufferedSerialWriter<Tx<USART0>>,
-    pub serial_rx: Rx<USART1>,
+    pub serial_rx: MessageReader<Rx<USART1>>,
     pub serial_writer: BufferedSerialWriter<Tx<USART1>>,
     pub buzzer: PB10<Output<PushPull>>,
     pub power_latch: PB2<Output<PushPull>>,
@@ -305,9 +306,9 @@ impl Hoverboard {
         }
 
         Hoverboard {
-            serial_remote_rx,
+            serial_remote_rx: MessageReader::new(serial_remote_rx),
             serial_remote_writer,
-            serial_rx,
+            serial_rx: MessageReader::new(serial_rx),
             serial_writer,
             buzzer: gpiob.pb10.into_push_pull_output(&mut gpiob.config),
             power_latch: gpiob.pb2.into_push_pull_output(&mut gpiob.config),

--- a/hoverkite-firmware/src/main.rs
+++ b/hoverkite-firmware/src/main.rs
@@ -9,6 +9,7 @@ mod util;
 
 #[cfg(feature = "primary")]
 use hoverkite_protocol::Command;
+use hoverkite_protocol::MessageReader;
 // pick a panicking behavior
 use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
                      // use panic_abort as _; // requires nightly
@@ -21,8 +22,10 @@ use gd32f1x0_hal::{pac, prelude::*, watchdog::FreeWatchdog};
 use hoverboard::Hoverboard;
 #[cfg(feature = "primary")]
 use protocol::process_response;
-use protocol::{process_command, send_position, HoverboardExt};
+use protocol::{process_command, send_position};
 use util::clamp;
+
+use crate::protocol::HoverboardExt;
 
 const WATCHDOG_MILLIS: u32 = 1000;
 
@@ -80,7 +83,6 @@ fn main() -> ! {
     log!(hoverboard.response_tx(), "Ready");
 
     let mut last_position = 0;
-    let mut command_buffer = [0; 12];
     let mut command_len = 0;
     #[cfg(feature = "primary")]
     let mut proxy_response_buffer = [0; 100];
@@ -96,23 +98,27 @@ fn main() -> ! {
 
         // Read from the command USART if data is available.
         match hoverboard.command_rx().read() {
-            Ok(char) => {
-                command_buffer[command_len] = char;
-                command_len += 1;
+            Ok(message) => {
                 if process_command(
-                    &command_buffer[0..command_len],
+                    message,
                     &mut hoverboard,
                     &mut speed_limits,
                     &mut target_position,
                     &mut spring_constant,
                 ) {
                     command_len = 0;
-                } else if command_len >= command_buffer.len() {
-                    log!(hoverboard.response_tx(), "Command too long");
-                    command_len = 0;
                 }
             }
             Err(nb::Error::WouldBlock) => {}
+            // something like:
+            // Err(nb::Error::Other(ParseError)) => {
+            //     log!(
+            //         hoverboard.response_tx(),
+            //         "Unrecognised command {} or problem {:?}",
+            //         command[0],
+            //         err
+            //     );
+            // }
             Err(nb::Error::Other(e)) => {
                 log!(
                     hoverboard.response_tx(),

--- a/hoverkite-firmware/src/main.rs
+++ b/hoverkite-firmware/src/main.rs
@@ -21,8 +21,10 @@ use gd32f1x0_hal::{pac, prelude::*, watchdog::FreeWatchdog};
 use hoverboard::Hoverboard;
 #[cfg(feature = "primary")]
 use protocol::process_response;
-use protocol::{process_command, send_position, HoverboardExt};
+use protocol::{process_command, send_position};
 use util::clamp;
+
+use crate::protocol::HoverboardExt;
 
 const WATCHDOG_MILLIS: u32 = 1000;
 
@@ -80,7 +82,6 @@ fn main() -> ! {
     log!(hoverboard.response_tx(), "Ready");
 
     let mut last_position = 0;
-    let mut command_buffer = [0; 12];
     let mut command_len = 0;
     #[cfg(feature = "primary")]
     let mut proxy_response_buffer = [0; 100];
@@ -96,23 +97,23 @@ fn main() -> ! {
 
         // Read from the command USART if data is available.
         match hoverboard.command_rx().read() {
-            Ok(char) => {
-                command_buffer[command_len] = char;
-                command_len += 1;
-                if process_command(
-                    &command_buffer[0..command_len],
-                    &mut hoverboard,
-                    &mut speed_limits,
-                    &mut target_position,
-                    &mut spring_constant,
-                ) {
-                    command_len = 0;
-                } else if command_len >= command_buffer.len() {
-                    log!(hoverboard.response_tx(), "Command too long");
-                    command_len = 0;
-                }
-            }
+            Ok(message) => process_command(
+                message,
+                &mut hoverboard,
+                &mut speed_limits,
+                &mut target_position,
+                &mut spring_constant,
+            ),
             Err(nb::Error::WouldBlock) => {}
+            // something like:
+            // Err(nb::Error::Other(ParseError)) => {
+            //     log!(
+            //         hoverboard.response_tx(),
+            //         "Unrecognised command {} or problem {:?}",
+            //         command[0],
+            //         err
+            //     );
+            // }
             Err(nb::Error::Other(e)) => {
                 log!(
                     hoverboard.response_tx(),

--- a/hoverkite-firmware/src/protocol.rs
+++ b/hoverkite-firmware/src/protocol.rs
@@ -7,13 +7,12 @@ use core::{
     ops::{Deref, RangeInclusive},
 };
 use embedded_hal::blocking::serial::Write;
-use embedded_hal::serial::Read;
 use gd32f1x0_hal::{
     pac::{self, usart0},
     prelude::*,
     serial::{Rx, Tx},
 };
-use hoverkite_protocol::{Command, Message, MessageReader, ParseError};
+use hoverkite_protocol::{Command, Message, MessageReader};
 
 #[macro_export]
 macro_rules! log {
@@ -97,7 +96,7 @@ pub fn process_command(
     speed_limits: &mut RangeInclusive<i16>,
     target_position: &mut Option<i64>,
     spring_constant: &mut i64,
-) -> bool {
+) {
     match message {
         Message::SecondaryCommand(sc) => {
             forward_command(hoverboard, &sc.0);
@@ -189,7 +188,6 @@ pub fn process_command(
             Command::PowerOff => poweroff(hoverboard),
         },
     }
-    true
 }
 
 pub trait HoverboardExt {

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -206,31 +206,44 @@ impl Message {
 
 pub struct MessageReader<R: embedded_hal::serial::Read<u8>> {
     reader: R,
-    buf: [u8; 12],
+    buffer: [u8; 12],
+    length: usize,
 }
 
 impl<R: embedded_hal::serial::Read<u8>> MessageReader<R> {
     pub fn new(reader: R) -> Self {
         Self {
             reader,
-            buf: [0; 12],
+            buffer: [0; 12],
+            length: 0,
         }
     }
 }
 
 impl<R: embedded_hal::serial::Read<u8>> embedded_hal::serial::Read<Message> for MessageReader<R> {
-    type Error = nb::Error<ParseError>;
+    type Error = ParseError;
 
     fn read(&mut self) -> nb::Result<Message, Self::Error> {
-        todo!()
-
-        // match self.reader.read()
-        // command_buffer[command_len] = char;
-        // command_len += 1;
-        // if command_len >= command_buffer.len() {
-        //     log!(hoverboard.response_tx(), "Command too long");
-        //     command_len = 0;
-        // }
+        if self.length >= self.buffer.len() {
+            // If we're about to overflow the buffer and we
+            // haven't managed to parse a command yet then
+            // bail.
+            self.length = 0;
+            return Err(Other(ParseError));
+        }
+        let byte = self.reader.read().map_err(|_e| {
+            // FIXME: forward this error on properly
+            Other(ParseError)
+        })?;
+        self.buffer[self.length] = byte;
+        self.length += 1;
+        let parsed = Message::parse(&self.buffer[..self.length]);
+        if !matches!(parsed, Err(WouldBlock)) {
+            // We either got a message or parsing failed.
+            // Either way, clear the buffer
+            self.length = 0;
+        }
+        parsed
     }
 }
 

--- a/hoverkite-protocol/src/lib.rs
+++ b/hoverkite-protocol/src/lib.rs
@@ -204,6 +204,36 @@ impl Message {
     }
 }
 
+pub struct MessageReader<R: embedded_hal::serial::Read<u8>> {
+    reader: R,
+    buf: [u8; 12],
+}
+
+impl<R: embedded_hal::serial::Read<u8>> MessageReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            buf: [0; 12],
+        }
+    }
+}
+
+impl<R: embedded_hal::serial::Read<u8>> embedded_hal::serial::Read<Message> for MessageReader<R> {
+    type Error = nb::Error<ParseError>;
+
+    fn read(&mut self) -> nb::Result<Message, Self::Error> {
+        todo!()
+
+        // match self.reader.read()
+        // command_buffer[command_len] = char;
+        // command_len += 1;
+        // if command_len >= command_buffer.len() {
+        //     log!(hoverboard.response_tx(), "Command too long");
+        //     command_len = 0;
+        // }
+    }
+}
+
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
TODO: create a new error type that includes the error from the underlying reader as a variant.