### PR TITLE
silence dead-code warnings

### DIFF
--- a/hoverkite-firmware/src/hoverboard.rs
+++ b/hoverkite-firmware/src/hoverboard.rs
@@ -29,6 +29,7 @@ use gd32f1x0_hal::{
 
 const USART_BAUD_RATE: u32 = 115200;
 const MOTOR_PWM_FREQ_HERTZ: u32 = 16000;
+#[allow(dead_code)]
 const CURRENT_OFFSET_DC: u16 = 1073;
 
 struct Shared {

--- a/hoverkite-firmware/src/main.rs
+++ b/hoverkite-firmware/src/main.rs
@@ -9,7 +9,9 @@ mod util;
 
 #[cfg(feature = "primary")]
 use hoverkite_protocol::Command;
-use hoverkite_protocol::{Response, SideResponse};
+#[cfg(feature = "secondary")]
+use hoverkite_protocol::Response;
+use hoverkite_protocol::SideResponse;
 // pick a panicking behavior
 use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
                      // use panic_abort as _; // requires nightly
@@ -25,6 +27,7 @@ use protocol::process_response;
 use protocol::{process_command, send_position, HoverboardExt};
 use util::clamp;
 
+#[cfg(feature = "secondary")]
 use crate::protocol::THIS_SIDE;
 
 const WATCHDOG_MILLIS: u32 = 1000;

--- a/hoverkite-firmware/src/motor.rs
+++ b/hoverkite-firmware/src/motor.rs
@@ -61,12 +61,19 @@ impl HallSensors {
 }
 
 pub struct Motor {
+    #[allow(dead_code)]
     green_high: PA10<Alternate<AF2>>,
+    #[allow(dead_code)]
     blue_high: PA9<Alternate<AF2>>,
+    #[allow(dead_code)]
     yellow_high: PA8<Alternate<AF2>>,
+    #[allow(dead_code)]
     green_low: PB15<Alternate<AF2>>,
+    #[allow(dead_code)]
     blue_low: PB14<Alternate<AF2>>,
+    #[allow(dead_code)]
     yellow_low: PB13<Alternate<AF2>>,
+    #[allow(dead_code)]
     emergency_off: PB12<Alternate<AF2>>,
     pub pwm: Pwm,
     hall_sensors: HallSensors,
@@ -330,10 +337,12 @@ impl Pwm {
         }
     }
 
+    #[allow(dead_code)]
     pub fn automatic_output_disable(&mut self) {
         self.timer.cchp.modify(|_, w| w.oaen().manual());
     }
 
+    #[allow(dead_code)]
     pub fn automatic_output_enable(&mut self) {
         self.timer.cchp.modify(|_, w| w.oaen().automatic());
     }


### PR DESCRIPTION
I suspect that a bunch of them will disappear when the motor module gets moved into a different crate, but it should be reasonably easy to revert at that point.