### PR TITLE
add new issues and PRs to kanban board

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -5,16 +5,15 @@ on:
     types: [opened]
   pull_request:
     types: [opened]
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
     name: Add to Kanban Board
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: Add NEW issues and pull requests to kanban board
+    - name: Add new issues and pull requests to kanban board
       uses: srggrs/assign-one-project-github-action@1.2.1
-      if: github.event.action == 'opened'
       with:
         project: 'https://github.com/hoverkite/hoverkite/projects/2'

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,20 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Add to Kanban Board
+    steps:
+    - name: Add NEW issues and pull requests to kanban board
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/hoverkite/hoverkite/projects/2'


### PR DESCRIPTION
I got bored of having to click "Add cards" whenever I make a new pull request, so this is an attempt to automate things.

It uses this thing: https://github.com/marketplace/actions/assign-to-one-project

Looks like it already worked :D 
![Screenshot 2021-05-13 at 16 26 02](https://user-images.githubusercontent.com/254647/118147951-00bc2380-b408-11eb-998c-cdb03bf9f3c1.png)
