### PR TITLE
Allow parsing partial buffer

### DIFF
--- a/cross/hoverkite-firmware/src/protocol.rs
+++ b/cross/hoverkite-firmware/src/protocol.rs
@@ -80,7 +80,7 @@ where
 /// Process the given response from the secondary board.
 #[cfg(feature = "primary")]
 pub fn process_response(response: &[u8], hoverboard: &mut Hoverboard) -> bool {
-    match SideResponse::parse(response) {
+    match SideResponse::parse_exact(response) {
         Ok(side_response) => {
             side_response.write_to(hoverboard.response_tx()).unwrap();
             if side_response.response == Response::PowerOff {

--- a/messages/src/response.rs
+++ b/messages/src/response.rs
@@ -234,6 +234,10 @@ mod tests {
             SideResponse::parse(b"x"),
             Err(Other((ProtocolError::InvalidSide(b'x'), 1)))
         );
+        assert_eq!(
+            SideResponse::parse_exact(b"x"),
+            Err(Other(ProtocolError::InvalidSide(b'x')))
+        );
     }
 
     #[test]
@@ -242,11 +246,16 @@ mod tests {
             SideResponse::parse(b"Lx"),
             Err(Other((ProtocolError::InvalidCommand(b'x'), 2)))
         );
+        assert_eq!(
+            SideResponse::parse_exact(b"Lx"),
+            Err(Other(ProtocolError::InvalidCommand(b'x')))
+        );
     }
 
     #[test]
     fn parse_empty() {
         assert_eq!(SideResponse::parse(b""), Err(WouldBlock));
+        assert_eq!(SideResponse::parse_exact(b""), Err(WouldBlock));
     }
 
     #[test_case(b"RI" ; "position")]
@@ -263,6 +272,10 @@ mod tests {
                 SideResponse::parse(&partial_response[..length]),
                 Err(WouldBlock)
             );
+            assert_eq!(
+                SideResponse::parse_exact(&partial_response[..length]),
+                Err(WouldBlock)
+            );
         }
     }
 
@@ -271,6 +284,10 @@ mod tests {
         assert_eq!(
             SideResponse::parse(b"RCx"),
             Err(Other((ProtocolError::InvalidByte(b'x'), 3)))
+        );
+        assert_eq!(
+            SideResponse::parse_exact(b"RCx"),
+            Err(Other(ProtocolError::InvalidByte(b'x')))
         );
     }
 

--- a/messages/src/response.rs
+++ b/messages/src/response.rs
@@ -339,6 +339,10 @@ mod tests {
         let mut buffer = Vec::new();
         side_response.write_to_std(&mut buffer).unwrap();
 
+        assert_eq!(
+            SideResponse::parse(&mut buffer),
+            Ok((side_response.clone(), buffer.len()))
+        );
         assert_eq!(SideResponse::parse_exact(&mut buffer), Ok(side_response));
     }
 
@@ -363,6 +367,10 @@ mod tests {
         side_response.write_to_std(&mut buffer).unwrap();
         buffer.push(42);
 
+        assert_eq!(
+            SideResponse::parse(&mut buffer),
+            Ok((side_response, buffer.len() - 1))
+        );
         assert_eq!(
             SideResponse::parse_exact(&mut buffer),
             Err(Other(ProtocolError::MessageTooLong))

--- a/messages/src/response.rs
+++ b/messages/src/response.rs
@@ -229,10 +229,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_invalid() {
+    fn parse_invalid_side() {
         assert_eq!(
             SideResponse::parse(b"x"),
             Err(Other((ProtocolError::InvalidSide(b'x'), 1)))
+        );
+    }
+
+    #[test]
+    fn parse_invalid_command() {
+        assert_eq!(
+            SideResponse::parse(b"Lx"),
+            Err(Other((ProtocolError::InvalidCommand(b'x'), 2)))
         );
     }
 


### PR DESCRIPTION
Adds a method which parses a response and returns the length that was parsed (or failed to parse), to avoid the need to loop over each possible prefix.