### PR TITLE
have a go at using deku to derive parsing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +168,64 @@ name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+
+[[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deku"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd7c0c75aa0bd698f74c896763ec1a1f455a71fde7a7df322c47fb041cda59"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee75b62abc0e5377eb11e531c93f42ca304f0d38c10727f166d8536049d6c9a4"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "discard"
@@ -212,6 +282,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "gilrs"
@@ -283,6 +359,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indenter"
@@ -387,6 +469,7 @@ dependencies = [
  "abc-parser",
  "arrayvec",
  "color-backtrace",
+ "deku",
  "displaydoc",
  "embedded-hal",
  "eyre",
@@ -505,6 +588,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +620,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "regex"
@@ -717,6 +816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +831,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -747,6 +858,35 @@ dependencies = [
  "quote",
  "syn",
  "version_check",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -863,3 +1003,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -12,6 +12,7 @@ log = { version = "0.4.14", optional = true }
 nb = "1.0.0"
 serialport = { version = "4.0.0", optional = true }
 slice-deque = { version = "0.3.0", optional = true}
+deku = "0.12.2"
 
 [dev-dependencies]
 abc-parser = "0.3.0"

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -8,6 +8,7 @@ mod response;
 mod util;
 
 pub use command::{Command, DirectedCommand, Note, SpeedLimits};
+use deku::prelude::*;
 pub use error::ProtocolError;
 pub use response::{Response, SideResponse};
 
@@ -32,9 +33,12 @@ impl<W: std::io::Write> embedded_hal::blocking::serial::Write<u8> for WriteCompa
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, DekuRead, DekuWrite)]
+#[deku(type = "u8")]
 pub enum Side {
+    #[deku(id = "b'L'")]
     Left,
+    #[deku(id = "b'R'")]
     Right,
 }
 

--- a/messages/src/util.rs
+++ b/messages/src/util.rs
@@ -1,4 +1,8 @@
+use std::num::NonZeroU32;
+
 use crate::ProtocolError;
+use deku::bitvec::{BitSlice, BitVec, Msb0};
+use deku::prelude::*;
 
 pub fn ascii_to_bool(char: u8) -> Result<bool, ProtocolError> {
     match char {
@@ -14,4 +18,24 @@ pub fn bool_to_ascii(on: bool) -> u8 {
     } else {
         b'0'
     }
+}
+
+pub fn read_bool(rest: &BitSlice<Msb0, u8>) -> Result<(&BitSlice<Msb0, u8>, bool), DekuError> {
+    let (rest, value) = u8::read(rest, ())?;
+    Ok((
+        rest,
+        ascii_to_bool(value).map_err(|_| DekuError::Assertion("invalid bool".to_string()))?,
+    ))
+}
+
+pub fn write_bool(output: &mut BitVec<Msb0, u8>, field_a: bool) -> Result<(), DekuError> {
+    let value = bool_to_ascii(field_a);
+    value.write(output, ())
+}
+
+pub fn read_option_nonzerou32(
+    rest: &BitSlice<Msb0, u8>,
+) -> Result<(&BitSlice<Msb0, u8>, Option<NonZeroU32>), DekuError> {
+    let (rest, value) = u32::read(rest, ())?;
+    Ok((rest, NonZeroU32::new(value)))
 }


### PR DESCRIPTION
This was surprisingly easy. It's only 86 lines for Command/DirectedCommand, where the manual serialisation is 122 (and we could probably delete a bunch of tests)

The main thing that screws us over is our custom serialisation of bools, and that "the field that you're decorating" is not available when writing custom writers (only &self), so you to have to re-match to get the value out. If there was a way to clean that up, it would get us down to ~62 lines. (I could probably have added a newtype around the bool variants, but I didn't want to. Maybe there is a serde-like serialize_with approach that would work?)

The other thing I needed to treat specially was Option<NonZeroU32>, which defaults to tripping an assertion in deku when you try to round-trip None.