### PR TITLE
wrap kitebox's 'cargo run' in a kiteboxcontrol util so that we can add binary capnproto messages later

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902e14c8b21b6f56f8d21a1c5de34aa3423acc61b136e47ec591d0758c3e77be"
+
+[[package]]
 name = "embassy-embedded-hal"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,29 @@ dependencies = [
  "embedded-storage",
  "embedded-storage-async",
  "nb 1.1.0",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
+dependencies = [
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1000,6 +1029,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kiteboxcontrol"
+version = "0.1.0"
+dependencies = [
+ "embassy",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync",
+ "log",
+ "serialport 4.7.0",
+ "static_cell",
 ]
 
 [[package]]
@@ -1822,6 +1864,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_cell"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89b0684884a883431282db1e4343f34afc2ff6996fe1f4a1664519b66e14c1e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = "2"
 
 members = [
+    "kiteboxcontrol",
     "hovercontrol",
     "messages",
     "st3215",

--- a/cross/kitebox/.cargo/config.toml
+++ b/cross/kitebox/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.xtensa-esp32-none-elf]
-runner = "espflash flash --monitor"
+# `in` is https://crates.io/crates/in-directory
+runner = "in ../../kiteboxcontrol cargo +stable run -- flash"
 
 [env]
 ESP_LOG="INFO"

--- a/kiteboxcontrol/Cargo.toml
+++ b/kiteboxcontrol/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kiteboxcontrol"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+embassy = "0.0.0"
+embassy-executor = { version = "0.7.0", features = ["arch-std", "executor-thread"]}
+embassy-futures = "0.1.1"
+embassy-sync = { version = "0.6.2", features = ["std"] }
+log = "0.4.26"
+serialport = "4.7.0"
+static_cell = "2.1.0"

--- a/kiteboxcontrol/src/main.rs
+++ b/kiteboxcontrol/src/main.rs
@@ -1,0 +1,170 @@
+use std::{io::Stdin, process::Stdio, time::Duration};
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    channel::{Channel, Receiver, Sender},
+};
+use log::error;
+use serialport::SerialPort;
+
+const BAUD_RATE: u32 = 115_200;
+
+/**
+ * This program is used as the target.xtensa-esp32-none-elf.runner for kitebox.
+ *
+ * This lets us send binary messages over the usb serial adapter and decode them for displaying
+ * to the user or sending to rerun.io as we see fit.
+ */
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut args = std::env::args().collect::<Vec<String>>();
+
+    println!("boxctl starting with args {}", args.join(" "));
+
+    if args.get(1) == Some(&"flash".to_string()) {
+        // hack because we're forced to cd out of cross/kitebox to run cargo
+        let firmware_path = args[2].clone();
+        if !std::fs::exists(&firmware_path).unwrap() {
+            let new_path = String::from("../cross/kitebox/") + &firmware_path;
+            if std::fs::exists(&new_path).unwrap() {
+                args[2] = new_path
+            } else {
+                panic!("can't find {firmware_path} or {new_path}");
+            }
+        }
+        // Forward the "flash" argument + all others on to espflash
+        let status = std::process::Command::new("espflash")
+            .args(&args[1..])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .expect("Failed to execute espflash flash command");
+
+        assert_eq!(status.code().unwrap(), 0);
+    }
+    let status = std::process::Command::new("espflash")
+        .arg("reset")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("Failed to execute espflash reset command");
+
+    assert_eq!(status.code().unwrap(), 0);
+
+    let port_path = std::env::var("ESPFLASH_PORT").expect("ESPFLASH_PORT env var must be set");
+    let port = match serialport::new(&port_path, BAUD_RATE)
+        .timeout(Duration::from_secs(60 * 60))
+        .open()
+    {
+        Ok(port) => port,
+        Err(e) => {
+            error!("Failed to open serial port {}: {}", port_path, e);
+            std::process::exit(1);
+        }
+    };
+    let port_tx = port.try_clone().unwrap();
+
+    let stdin_rx = spawn_stdin_channel(std::io::stdin());
+    let tty_rx = spawn_tty_rx_channel(port);
+    let tty_tx = spawn_tty_tx_channel(port_tx);
+
+    tty_tx.send("p".into()).await;
+
+    loop {
+        match select(stdin_rx.receive(), tty_rx.receive()).await {
+            Either::First(stdin_msg) => {
+                tty_tx.try_send(stdin_msg).unwrap();
+            }
+            Either::Second(tty_msg) => {
+                println!("{tty_msg}")
+            }
+        };
+    }
+}
+
+fn spawn_stdin_channel(stdin: Stdin) -> Receiver<'static, CriticalSectionRawMutex, String, 10> {
+    #[allow(non_upper_case_globals)]
+    static stdin_channel: Channel<CriticalSectionRawMutex, String, 10> = Channel::new();
+
+    let tx = stdin_channel.sender();
+    std::thread::spawn(move || {
+        loop {
+            let mut buffer = String::new();
+            // FIXME(probably never): make stdin unbuffered and read a char at a time,
+            // so we can handle arrow keys without needing to press enter, like we used to.
+            // In practice, it would be better to just get the accelerometer or game controller
+            // working, and stop worrying about the keyboard.
+            stdin.read_line(&mut buffer).unwrap();
+            tx.try_send(buffer).unwrap();
+        }
+    });
+
+    stdin_channel.receiver()
+}
+
+fn spawn_tty_rx_channel(
+    mut port: Box<dyn SerialPort>,
+) -> Receiver<'static, CriticalSectionRawMutex, String, 10> {
+    #[allow(non_upper_case_globals)]
+    static tty_rx_channel: Channel<CriticalSectionRawMutex, String, 10> = Channel::new();
+
+    let tx = tty_rx_channel.sender();
+    std::thread::spawn(move || {
+        loop {
+            let mut buf = [0u8];
+            let count = port.read(&mut buf).unwrap();
+            assert_eq!(count, 1);
+            match buf[0] {
+                b'#' => todo!("read message as capnproto-encoded message"),
+                _ => {
+                    let mut line = Vec::from(&buf);
+                    loop {
+                        let count = port.read(&mut buf).unwrap();
+                        assert_eq!(count, 1);
+                        match buf[0] {
+                            b'\n' => break,
+                            o => line.push(o),
+                        }
+                    }
+                    tx.try_send(String::from_utf8_lossy(&line).to_string())
+                        .unwrap()
+                }
+            }
+        }
+    });
+
+    tty_rx_channel.receiver()
+}
+
+fn spawn_tty_tx_channel(
+    port: Box<dyn SerialPort>,
+) -> Sender<'static, CriticalSectionRawMutex, String, 10> {
+    #[allow(non_upper_case_globals)]
+    static tty_tx_channel: Channel<CriticalSectionRawMutex, String, 10> = Channel::new();
+
+    let tx = tty_tx_channel.sender();
+    let rx = tty_tx_channel.receiver();
+    std::thread::spawn(move || {
+        static TTY_TX_THREAD_EXECUTOR: static_cell::StaticCell<embassy_executor::Executor> =
+            static_cell::StaticCell::new();
+        let executor = TTY_TX_THREAD_EXECUTOR.init(embassy_executor::Executor::new());
+        executor.run(|spawner| {
+            spawner.spawn(_forward_tty_tx_channel(port, rx)).unwrap();
+        })
+    });
+
+    tx
+}
+
+#[embassy_executor::task]
+async fn _forward_tty_tx_channel(
+    mut port: Box<dyn SerialPort>,
+    rx: Receiver<'static, CriticalSectionRawMutex, String, 10>,
+) {
+    loop {
+        let msg = rx.receive().await;
+        port.write_all(msg.as_bytes()).unwrap();
+    }
+}


### PR DESCRIPTION
Our existing hoverkite-firmware is flashed using openocd. The hovercontrol app then talks over a separate usb serial port adapter.

For the kitebox firmware, we use usb for both flashing and comms. We use `runner = "espflash flash --monitor"` so that we get to see the serial traffic and type commands. I would like to be able to add binary commands and binary responses, so that I can plug things into rerun.io and debug using 3d graphics (and also collect data for training a model). I've made my own `runner` that can flash the firmware and then send binary commands and decode binary responses.

Unfortunately `cat | espflash flash --monitor | cat` doesn't work, because the monitor wants to be talking to a tty. I've taken the approach of separating out the flash and monitor steps. Annoyingly, this means that we miss any logs statements that happen during startup. It turns out that espflash is open source at https://github.com/esp-rs/espflash, so it might be possible to patch `espflash flash --monitor` to not require a tty.

The plan is to make every line that starts with a # be interpreted as a binary message (parsed and then printed with `{:?}` or logged to rerun.io), and every normal line pass through using the existing mechanisms.

I have hooked everything up using the embassy executor on the laptop, so it's similar to how the kitebox firmware works. I've used a couple of threads to talk to stdin and the serialport library because they both do blocking reads, but the main loop is still the same select loop as the firmware, pulling messages from channels and actioning/forwarding them.